### PR TITLE
Variable Authentication: Allow users to authenticate into Jenkins with Hubot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ Yardmaster is a Hubot plugin that allows you to interact with Jenkins instance r
 ### Environment Variables Required:
 * HUBOT_JENKINS_URL - Jenkins base URL
 * HUBOT_JENKINS_USER - Jenins admin user
-* HUBOT_JENKINS_USER_API_KEY - Admin user API key. Not your password. Find at "{HUBOT_JENKINS_URL}/{HUBOT_JENKINS_USER}/configure" 
+* HUBOT_JENKINS_USER_API_KEY - Admin user API key. Not your password. Find at "{HUBOT_JENKINS_URL}/{HUBOT_JENKINS_USER}/configure"
 * HUBOT_JENKINS_JOB_NAME - Hubot job name on Jenkins (optional)
 * GITHUB_TOKEN - Github API Auth token (optional)
 * MONITOR_JENKINS - true | false : If true, hubot will monitor the jenkins queue and start nodes when job queue is greater than 2.
 
 ### Commands:
+* hubot jenkins auth set {username} {api key} - Give Hubot your credentials to use when you issue commands.
+* hubot jenkins auth - See what Jenkins username the Hubot has for you.
+* hubot jenkins auth clear - Clear your Jenkins credentials.
 * hubot switch|change|build {job} to|with {branch} - Change job to branch on Jenkins and build.
 * hubot (show|current|show current) branch for {job} - Shows current branch for job on Jenkins.
 * hubot (go) build yourself|(go) ship yourself - Rebuilds default branch if set.
@@ -30,6 +33,6 @@ Yardmaster is a Hubot plugin that allows you to interact with Jenkins instance r
 * hubot (show|show last|last) (build) (date|time) for {job} - shows the last build date and time for a job
 * hubot (start|build) (builder|slave|node) - starts one of the available slave nodes.
 * hubot send reinforcements - starts one of the available slave nodes.
- 
-#### Author: 
+
+#### Author:
 #### @riveramj

--- a/src/yardmaster.coffee
+++ b/src/yardmaster.coffee
@@ -67,7 +67,7 @@ checkAuthentcation = (robot, msg) ->
   if jenkinsUsername?
     msg.send "You are authenticated with Jenkins as #{jenkinsUsername}"
   else
-    msg.send "I don't seem to have any Jenkins credentials for you."
+    msg.send "I don't seem to have any Jenkins credentials for you. Commands you issue will use my Jenkins credentials."
 
 clearAuthentication = (robot, msg) ->
   yardmaster = robot.brain.get('yardmaster') || {}
@@ -77,9 +77,9 @@ clearAuthentication = (robot, msg) ->
     delete yardmaster.auth[msg.message.user]
     robot.brain.set 'yardmaster', yardmaster
 
-    msg.send "I've removed your Jenkins credentials."
+    msg.send "I've removed your Jenkins credentials. Commands you issue will use my Jenkins credentials."
   else
-    msg.send "I don't seem to have any Jenkins credentials for you."
+    msg.send "I don't seem to have any credentials for you. Commands you issue will use my Jenkins credentials."
 
 setAuthentication = (robot, msg) ->
   jenkinsUsername = msg.match[1]

--- a/src/yardmaster.coffee
+++ b/src/yardmaster.coffee
@@ -72,34 +72,38 @@ setAuthentication = (robot, msg) ->
   msg.send "Done. From now on I'll authenticate your requests to jenkins as #{jenkinsUsername}."
 
 getByFullUrl = (robot, msg, url, callback) ->
-  robot.http(url)
-    .auth("#{jenkinsUser}", "#{jenkinsUserAPIKey}")
-    .get() (err, res, body) ->
-      if err
-        robot.send "Encountered an error :( #{err}"
-      else
-        callback(res, body)
+  withAuthentication robot, msg, (user, apiKey) ->
+    robot.http(url)
+      .auth("#{user}", "#{apiKey}")
+      .get() (err, res, body) ->
+        if err
+          robot.send "Encountered an error :( #{err}"
+        else
+          callback(res, body)
 
 get = (robot, msg, queryOptions, callback) ->
-  robot.http("#{jenkinsURL}/#{queryOptions}")
-    .auth("#{jenkinsUser}", "#{jenkinsUserAPIKey}")
-    .get() (err, res, body) ->
-      if err
-        msg.send "Encountered an error :( #{err}"
-      else
-        callback(res, body)
+  withAuthentication robot, msg, (user, apiKey) ->
+    robot.http("#{jenkinsURL}/#{queryOptions}")
+      .auth("#{user}", "#{apiKey}")
+      .get() (err, res, body) ->
+        if err
+          msg.send "Encountered an error :( #{err}"
+        else
+          callback(res, body)
 
 post = (robot, msg, queryOptions, postOptions, callback) ->
-  robot.http("#{jenkinsURL}/#{queryOptions}")
-    .auth("#{jenkinsUser}", "#{jenkinsUserAPIKey}")
-    .post(postOptions) (err, res, body) ->
-      callback(err, res, body)
+  withAuthentication robot, msg, (user, apiKey) ->
+    robot.http("#{jenkinsURL}/#{queryOptions}")
+      .auth("#{user}", "#{apiKey}")
+      .post(postOptions) (err, res, body) ->
+        callback(err, res, body)
 
 postByFullUrl = (robot, msg, url, postOptions, callback) ->
-  robot.http(url)
-    .auth("#{jenkinsUser}", "#{jenkinsUserAPIKey}")
-    .post(postOptions) (err, res, body) ->
-      callback(err, res, body)
+  withAuthentication robot, msg, (user, apiKey) ->
+    robot.http(url)
+      .auth("#{user}", "#{apiKey}")
+      .post(postOptions) (err, res, body) ->
+        callback(err, res, body)
 
 ifJobEnabled = (robot, msg, job, callback) ->
   get robot, msg, "job/#{job}/config.xml", (res, body) ->

--- a/src/yardmaster.coffee
+++ b/src/yardmaster.coffee
@@ -535,7 +535,7 @@ module.exports = (robot) ->
     )
     cronjob.start()
 
-  robot.respond /yardmaster auth ([^ ]+) (.+)/i, (msg) ->
+  robot.respond /jenkins auth ([^ ]+) (.+)/i, (msg) ->
     setAuthentication(robot, msg)
 
   robot.respond /(switch|change|build) (.+) (to|with) (.+)\.?/i, (msg) ->

--- a/src/yardmaster.coffee
+++ b/src/yardmaster.coffee
@@ -587,7 +587,7 @@ module.exports = (robot) ->
     )
     cronjob.start()
 
-  robot.respond /jenkins auth/i, (msg) ->
+  robot.respond /jenkins auth$/i, (msg) ->
     checkAuthentcation(robot, msg)
 
   robot.respond /jenkins auth clear/i, (msg) ->

--- a/src/yardmaster.coffee
+++ b/src/yardmaster.coffee
@@ -207,9 +207,9 @@ buildBranch = (robot, msg, job, branch = "") ->
 
       joinedParameters = parameters.join('&')
 
-      post robot, "job/#{job}/buildWithParameters?#{joinedParameters}", "", buildFeedback(robot, msg, job, branch)
+      post robot, msg, "job/#{job}/buildWithParameters?#{joinedParameters}", "", buildFeedback(robot, msg, job, branch)
     else
-      post robot, "job/#{job}/build", "", buildFeedback(robot, msg, job, branch)
+      post robot, msg, "job/#{job}/build", "", buildFeedback(robot, msg, job, branch)
 
 getCurrentBranch = (body) ->
   branch = ""

--- a/src/yardmaster.coffee
+++ b/src/yardmaster.coffee
@@ -13,6 +13,9 @@
 #   MONITOR_JENKINS - true | false : If true, hubot will monitor the jenkins queue and start nodes when job queue is greater than 2.
 #
 # Commands:
+#   hubot jenkins auth set {username} {api key} - Give Hubot your credentials to use when you issue commands.
+#   hubot jenkins auth - See what Jenkins username the Hubot has for you.
+#   hubot jenkins auth clear - Clear your Jenkins credentials.
 #   hubot switch|change|build {job} to|with {branch} - Change job to branch on Jenkins and build.
 #   hubot (show|current|show current) branch for {job} - Shows current branch for job on Jenkins.
 #   hubot (go) build yourself|(go) ship yourself - Rebuilds default branch if set.


### PR DESCRIPTION
This PR creates the ability for a user to provide their own Jenkins authentication information to yardmaster so actions they request will be executed using their Jenkins account.

To authenticate you can do:

```
> hubot jenkins auth set farmdawgnation XXXXXXXXX
Attempting to authenticate you as farmdawgnation
Done. From now on I'll authenticate your requests to jenkins as farmdawgnation.
```

Additionally you can check your current authentication:

```
> hubot jenkins auth
You are authenticated with Jenkins as farmdawgnation
```

And clear your authentication

```
> hubot jenkins auth clear
I've removed your Jenkins credentials. Commands you issue will use my Jenkins credentials.
```