### PR TITLE
When in CSRF mode get a crumb & add it to the POST headers

### DIFF
--- a/src/yardmaster.coffee
+++ b/src/yardmaster.coffee
@@ -2,7 +2,8 @@
 #   Interact with Jenkins instance remotely. Build jobs, change branches, start builders, lock jobs... The list goes on.
 #
 # Dependencies:
-#   Nope
+#   xml2js
+#   cron
 #
 # Configuration:
 #   HUBOT_JENKINS_URL - Jenkins base URL
@@ -38,6 +39,7 @@
 #
 # Author:
 #   @riveramj
+#   @lwebb - fixed problems with CSRF and post requests
 
 {parseString} = require 'xml2js'
 cronJob = require('cron').CronJob
@@ -58,6 +60,17 @@ withAuthentication = (robot, msg, callback) ->
   apiKey = authStructure.apiKey || jenkinsUserAPIKey
 
   callback(user, apiKey)
+
+withCrumb = (robot, msg, callback) ->
+  withAuthentication robot, msg, (user, apiKey) ->
+    robot.http("#{jenkinsURL}/crumbIssuer/api/json")
+      .auth("#{user}", "#{apiKey}")
+      .get() (err, res, body) ->
+        if err
+          msg.sent "Problem getting a CSRF token #{err}"
+        else
+          json = JSON.parse(body)
+          callback(user, apiKey, json.crumb)
 
 checkAuthentcation = (robot, msg) ->
   yardmaster = robot.brain.get('yardmaster') || {}
@@ -128,16 +141,18 @@ get = (robot, msg, queryOptions, callback) ->
           callback(res, body)
 
 post = (robot, msg, queryOptions, postOptions, callback) ->
-  withAuthentication robot, msg, (user, apiKey) ->
+  withCrumb robot, msg, (user, apiKey, crumb) ->
     robot.http("#{jenkinsURL}/#{queryOptions}")
       .auth("#{user}", "#{apiKey}")
+      .headers('Jenkins-Crumb': crumb)
       .post(postOptions) (err, res, body) ->
         callback(err, res, body)
 
 postByFullUrl = (robot, msg, url, postOptions, callback) ->
-  withAuthentication robot, msg, (user, apiKey) ->
+  withCrumb robot, msg, (user, apiKey, crumb) ->
     robot.http(url)
       .auth("#{user}", "#{apiKey}")
+      .headers('Jenkins-Crumb': crumb)
       .post(postOptions) (err, res, body) ->
         callback(err, res, body)
 


### PR DESCRIPTION
Allows hubot to get a crumb from Jenkins prior to submitting a post request (such as to launch a build) when CSRF is enabled on the server

https://wiki.jenkins.io/display/JENKINS/Remote+access+API#RemoteaccessAPI-CSRFProtection

I suppose that there should be a toggle on or off & better error checking etc. but I don't like writing coffee script it makes my head hurt